### PR TITLE
Add missing TypeScript module declarations

### DIFF
--- a/packages/jasmine-jquery-matchers/index.d.ts
+++ b/packages/jasmine-jquery-matchers/index.d.ts
@@ -26,3 +26,5 @@ declare namespace jasmine {
     toHaveDescendantWithText(sel: string, text: string | RegExp): boolean
   }
 }
+
+declare module "jest-jquery-matchers";

--- a/packages/jest-jquery-matchers/index.d.ts
+++ b/packages/jest-jquery-matchers/index.d.ts
@@ -26,3 +26,5 @@ declare namespace jest {
     toHaveDescendantWithText(sel: string, text: string | RegExp): boolean
   }
 }
+
+declare module "jest-jquery-matchers";


### PR DESCRIPTION
First of all, thanks for the plugin. We are migrating from Karma to Jest, and this package helps a lot! :)

According to the README, the matchers need to be registered like this:
```ts
import * as matchers from 'jest-jquery-matchers';
beforeEach(function () {
    jest.addMatchers(matchers);
});
```

We are using TypeScript (2.6.2) and all of our tests are written in TS. This import will throw the following error: `'.../node_modules/jest-jquery-matchers/index.d.ts' is not a module`.

To fix this error message 'jest-jquery-matchers' needs to be declared as a module. This PR fixes this issue.